### PR TITLE
Fix Invalid MD5 when using / in protocol document

### DIFF
--- a/lib/avro/protocol.php
+++ b/lib/avro/protocol.php
@@ -89,7 +89,7 @@ class AvroProtocol
    */
   public function __toString()
   {
-    return json_encode($this->to_avro());
+    return json_encode($this->to_avro(), JSON_UNESCAPED_SLASHES);
   }
   
   /**


### PR DESCRIPTION
The MD5 is built from a json encoded array, however PHP json_encode add backslash in string when encoutering a slash.
i.e. A string like 'foo/bar' is then transformed to 'foo\/bar' resulting in a wrong MD5 value
